### PR TITLE
fix: allow production domains in CORS configuration

### DIFF
--- a/backend/server-integrated.cjs
+++ b/backend/server-integrated.cjs
@@ -124,23 +124,21 @@ global.httpServer = httpServer;
 const PORT = process.env.PORT || 5002;
 const JWT_SECRET = process.env.JWT_SECRET || 'your_jwt_secret';
 
-// CORS configuration - environment aware
-const isDevelopment = process.env.NODE_ENV !== 'production';
-const allowedOrigins = isDevelopment 
-  ? [
-      'http://localhost:3000',    // Vite dev server
-      'http://localhost:8081',    // Your current dev port
-      'http://localhost:8080',    // Your current server port
-      'http://localhost:5173',    // Common Vite port
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:8081',
-      'http://127.0.0.1:8080',
-      'http://127.0.0.1:5173'
-    ]
-  : [
-      'https://clear.high-score.dev',  // Your production domain
-      'https://yourdomain.com'         // Add your actual production domain
-    ];
+// CORS configuration - allow development and production origins
+const allowedOrigins = [
+  // Development servers
+  'http://localhost:3000',    // Vite dev server
+  'http://localhost:8081',    // Current dev port
+  'http://localhost:8080',    // Current server port
+  'http://localhost:5173',    // Common Vite port
+  'http://127.0.0.1:3000',
+  'http://127.0.0.1:8081',
+  'http://127.0.0.1:8080',
+  'http://127.0.0.1:5173',
+  // Production domains
+  'https://clear.high-score.dev',
+  'https://believable-alignment-production.up.railway.app'
+];
 
 console.log('🌐 CORS Configuration:');
 console.log(`🔧 Environment: ${process.env.NODE_ENV || 'development'}`);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,9 +1,5 @@
 // Environment-aware API configuration
-const isDevelopment = import.meta.env.DEV || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-
-const API_BASE_URL = isDevelopment 
-  ? 'http://localhost:8080/api'  // Local development
-  : 'https://localease-service-hub-production.up.railway.app/api'; // Production
+import { API_BASE_URL, isDevelopment } from '@/config';
 
 console.log('🌐 API Configuration:', {
   environment: isDevelopment ? 'development' : 'production',

--- a/src/components/AdminChat.tsx
+++ b/src/components/AdminChat.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { apiClient } from '@/api/client';
 import { useToast } from '@/hooks/use-toast';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 
 interface ChatRoom {
   _id: string; // MongoDB ObjectId
@@ -92,7 +93,7 @@ const AdminChat: React.FC<AdminChatProps> = ({ onClose }) => {
     if (!token) return;
 
     // Create Socket.IO connection
-    const newSocket = io('http://localhost:5002', {
+    const newSocket = io(SOCKET_URL, {
       auth: {
         token: token
       },

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -30,6 +30,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { apiClient } from '@/api/client';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 
 interface Message {
   id: string;
@@ -134,7 +135,7 @@ const Chat: React.FC<ChatProps> = ({ onClose, selectedChatRoomId, chatRoomId, ch
     if (!token) return;
 
     // Create Socket.IO connection
-    const newSocket = io('http://localhost:5002', {
+    const newSocket = io(SOCKET_URL, {
       auth: { token },
       transports: ['websocket', 'polling']
     });

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -20,6 +20,7 @@ import { useNotifications } from '@/contexts/NotificationContext';
 import { apiClient } from '@/api/client';
 import Chat from './Chat';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 
 interface ChatRoom {
   _id: string; // MongoDB ObjectId
@@ -75,7 +76,7 @@ const ChatList: React.FC<ChatListProps> = ({ initialBookingId }) => {
     if (!token) return;
 
     // Create Socket.IO connection
-    const newSocket = io('http://localhost:5002', {
+    const newSocket = io(SOCKET_URL, {
       auth: { token },
       transports: ['websocket', 'polling']
     });

--- a/src/components/EnhancedAdminChat.tsx
+++ b/src/components/EnhancedAdminChat.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { apiClient } from '@/api/client';
 import { useToast } from '@/hooks/use-toast';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 
 interface ChatRoom {
   id: string;
@@ -115,7 +116,7 @@ const EnhancedAdminChat: React.FC<EnhancedAdminChatProps> = ({ onClose }) => {
     const token = localStorage.getItem('token');
     if (!token) return;
 
-    const newSocket = io('http://localhost:5002', {
+    const newSocket = io(SOCKET_URL, {
       auth: { token },
       transports: ['websocket', 'polling']
     });

--- a/src/components/RealTimeChatDemo.tsx
+++ b/src/components/RealTimeChatDemo.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 import { apiClient } from '@/api/client';
 
 const RealTimeChatDemo: React.FC = () => {
@@ -53,7 +54,7 @@ const RealTimeChatDemo: React.FC = () => {
     if (!token) return;
 
     // Create Socket.IO connection
-    const newSocket = io('http://localhost:5002', {
+    const newSocket = io(SOCKET_URL, {
       auth: { token },
       transports: ['websocket', 'polling']
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+const isDevelopment = import.meta.env.DEV ||
+  window.location.hostname === 'localhost' ||
+  window.location.hostname === '127.0.0.1';
+
+export const API_BASE_URL = isDevelopment
+  ? 'http://localhost:8080/api'
+  : 'https://believable-alignment-production.up.railway.app/api';
+
+export const SOCKET_URL = isDevelopment
+  ? 'http://localhost:5002'
+  : 'https://believable-alignment-production.up.railway.app';
+
+export { isDevelopment };

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -3,6 +3,7 @@ import { useAuth } from './AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { apiClient } from '@/api/client';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 
 interface NotificationContextType {
   unreadCount: number;
@@ -55,7 +56,7 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
     if (!token || !user) return;
 
     // Create Socket.IO connection
-    const socket = io('http://localhost:5002', {
+    const socket = io(SOCKET_URL, {
       auth: { token },
       transports: ['websocket', 'polling']
     });

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { SOCKET_URL } from '@/config';
 import { useAuth } from './AuthContext';
 
 interface SocketContextType {
@@ -48,7 +49,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
     }
 
     // Create socket connection
-    const socket = io('http://localhost:5002', {
+    const socket = io(SOCKET_URL, {
       transports: ['websocket', 'polling'],
       autoConnect: true,
     });


### PR DESCRIPTION
## Summary
- ensure Express and Socket.IO accept requests from production frontend and Railway backend by expanding CORS origin list
- point API client and socket connections at production Railway backend via centralized config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 108 problems (93 errors, 15 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689d0a205bb083218555e887f6802477